### PR TITLE
Modificação na função word_count

### DIFF
--- a/Lambda New Features.ipynb
+++ b/Lambda New Features.ipynb
@@ -58,17 +58,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "def word_count(review, word):\n",
-    "    cont = 0\n",
     "    review = review.lower()\n",
-    "    if word in review.lower():\n",
-    "        return review.count(word)\n",
-    "    else:\n",
-    "        return 0"
+    "    return review.count(word)"
    ]
   },
   {


### PR DESCRIPTION
método  .count()  já trata casos de 0 ocorrências de uma palavra em uma string